### PR TITLE
fix: use push trigger for rdev Docker build to get secrets access

### DIFF
--- a/.github/workflows/docker-build-rdev.yaml
+++ b/.github/workflows/docker-build-rdev.yaml
@@ -1,11 +1,11 @@
 name: Build and push Docker image (rdev)
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
     paths-ignore:
       - ".infra/**"
+  pull_request:
+    types: [labeled]
 
 permissions:
   id-token: write        # OIDC → ECR auth

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     web:
       image:
-        tag: sha-93ac645
+        tag: sha-7c079e7
       replicaCount: 1
       resources:
         requests:


### PR DESCRIPTION
## Summary

- Fix rdev Docker build failing with `[@octokit/auth-app] appId option is required`
- The `pull_request` trigger runs in a restricted security context without access to org-level secrets, so `create-github-app-token` cannot read the GitHub App credentials
- Switch to `push` + `pull_request: [labeled]` triggers to match the standard Argus bootstrap pattern (same as rnaquarium-gene-embedding-viewer-be and other working repos)

## Test plan

- [ ] Verify this push triggers the Docker build workflow and it passes the `create-github-app-token` step
- [ ] Confirm the Docker image is built and pushed to ECR successfully
